### PR TITLE
[VM] Try not using npm-publish

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,5 +2,3 @@ steps:
   - name: ':npm: Publish to npm'
     command: '.buildkite/run.sh .buildkite/publish.js'
     branches: master
-    agents:
-      queue: npm-publish


### PR DESCRIPTION
There doesn't seem to be any reason to use a separate queue for the npm publish step (i.e. it's not doing anything special), so switching to another queue to make management easier.

I'm not sure how to test that this doesn't break stuff without merging to master, since there's no obvious version?